### PR TITLE
Retrieve root’s user name thru userinfo instead of raw value

### DIFF
--- a/main.c
+++ b/main.c
@@ -163,24 +163,12 @@ int main(int argc, char **argv) {
 			setsid();
 	}
 
+	as = &root;
 	while (!auth) {
-		as = &root;
 		flush_vt(&vt);
-		if (!only_root) {
-			tty_echo_on(&vt);
-			while (1) {
-				prompt(vt.ios, "\nUnlock as [%s/%s]: ", user.name, root.name);
-				if (!*buf || !strcmp(buf, user.name)) {
-					as = &user;
-					break;
-				} else if (!strcmp(buf, root.name)) {
-					break;
-				}
-			}
-			tty_echo_off(&vt);
-		} else {
-			prompt(vt.ios, "\nPress [Enter] to unlock.\n");
-		}
+
+		if (!only_root)
+			as = (strcmp(as->name, root.name)) ? &root : &user;
 
 		prompt(vt.ios, "%s's password: ", as->name);
 		auth = authenticate(as, buf);


### PR DESCRIPTION
Some admnistrators can change default root login to enforce security.
