### PR TITLE
Handle interrupted VT_WAITACTIVE syscall

### DIFF
--- a/vt.c
+++ b/vt.c
@@ -103,7 +103,7 @@ void release_vt(vt_t *vt, int nr) {
 		die("release_vt() called with invalid argument");
 	if (ioctl(fd, VT_ACTIVATE, nr) < 0 ||
 			ioctl(fd, VT_WAITACTIVE, nr) < 0)
-		die("could not activate console # %d: %s", vt->nr, strerror(errno));
+		die("could not activate console # %d: %s", nr, strerror(errno));
 
 	if (vt->ios != NULL) {
 		fclose(vt->ios);


### PR DESCRIPTION
`VT_WAITACTIVE` syscall is likely to be interrupted if physlock is launched when the system goes to sleep.

The commit I propose here solves this problem. But I guess that if you want a 100% bullet-proof physlock, every syscall should be enclosed in a `while` loop, and retried if interrupted.

The commit I propose here is lightweight, it just handles the `VT_WAITACTIVE` syscall, because it's the one that is interrupted all the time when I use physlock.