### PR TITLE
Add option to mute kernel messages on console

### DIFF
--- a/config.h
+++ b/config.h
@@ -8,6 +8,9 @@ static const char * const TTY_DEVICE_BASE = "/dev/tty";
 /* full path to kernel sysrq control file:             */
 static const char * const SYSRQ_PATH = "/proc/sys/kernel/sysrq";
 
+/* full path to kernel printk file:			*/
+static const char * const PRINTK_PATH = "/proc/sys/kernel/printk";
+
 /* timeout (seconds) after failed authentication try:  */
 enum { AUTH_FAIL_TIMEOUT = 2 };
 

--- a/main.c
+++ b/main.c
@@ -38,6 +38,7 @@ static char buf[BUFLEN];
 static int oldvt;
 static vt_t vt;
 static int oldsysrq;
+static int oldprintk;
 
 void cleanup() {
 	static int in = 0;
@@ -45,6 +46,8 @@ void cleanup() {
 	if (!in++) {
 		if (oldsysrq > 0)
 			set_sysrq_state(SYSRQ_PATH, oldsysrq);
+		if (oldprintk > 1)
+			set_printk_console(PRINTK_PATH, oldprintk);
 		if (vt.fd >= 0)
 			reset_vt(&vt);
 		unlock_vt_switch();
@@ -99,7 +102,7 @@ int main(int argc, char **argv) {
 	uid_t uid;
 	userinfo_t *as, root, user;
 
-	oldvt = oldsysrq = vt.nr = vt.fd = -1;
+	oldvt = oldsysrq = oldprintk = vt.nr = vt.fd = -1;
 	vt.ios = NULL;
 
 	parse_options(argc, argv);
@@ -136,6 +139,12 @@ int main(int argc, char **argv) {
 		oldsysrq = get_sysrq_state(SYSRQ_PATH);
 		if (oldsysrq > 0)
 			set_sysrq_state(SYSRQ_PATH, 0);
+	}
+
+	if (options->mute_kernel_messages) {
+		oldprintk = get_printk_console(PRINTK_PATH);
+		if (oldprintk > 1)
+			set_printk_console(PRINTK_PATH, 1);
 	}
 
 	if (options->user) {

--- a/options.c
+++ b/options.c
@@ -28,7 +28,7 @@ static options_t _options;
 const options_t *options = (const options_t*) &_options;
 
 void print_usage() {
-	printf("usage: physlock [-dhLlsv] [-u user]\n");
+	printf("usage: physlock [-dhLlmsv] [-u user]\n");
 }
 
 void print_version() {
@@ -40,11 +40,12 @@ void parse_options(int argc, char **argv) {
 	
 	_options.detach = 0;
 	_options.disable_sysrq = 0;
+	_options.mute_kernel_messages = 0;
 	_options.only_lock = 0;
 	_options.only_unlock = 0;
 	_options.user = NULL;
 
-	while ((opt = getopt(argc, argv, "dhLlsu:v")) != -1) {
+	while ((opt = getopt(argc, argv, "dhLlmsu:v")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -60,6 +61,9 @@ void parse_options(int argc, char **argv) {
 				break;
 			case 'l':
 				_options.only_lock = 1;
+				break;
+			case 'm':
+				_options.mute_kernel_messages = 1;
 				break;
 			case 's':
 				_options.disable_sysrq = 1;

--- a/options.h
+++ b/options.h
@@ -22,6 +22,7 @@
 typedef struct options_s {
 	int detach;
 	int disable_sysrq;
+	int mute_kernel_messages;
 	int only_lock;
 	int only_unlock;
 	const char *user;

--- a/physlock.1
+++ b/physlock.1
@@ -3,7 +3,7 @@
 physlock \- lock all consoles / virtual terminals
 .SH SYNOPSIS
 .B physlock
-.RB [ \-dhLlsv ]
+.RB [ \-dhLlmsv ]
 .RB [ \-u
 .IR USER ]
 .SH DESCRIPTION
@@ -35,6 +35,9 @@ Only lock console switching and exit.
 Only enable (unlock) console switching and exit. This is useful when a prior
 instance of physlock has crashed and leaved the console switching mechanism
 locked.
+.TP
+.B \-m
+Mute kernel messages on console while physlock is runnning.
 .TP
 .B \-s
 Disable SysRq mechanism while physlock is running.

--- a/util.c
+++ b/util.c
@@ -112,42 +112,46 @@ static size_t write_file(const char *path, char *buf, size_t len) {
 	return nwritten;
 }
 
-int get_sysrq_state(const char *path) {
+/*
+ * Read integer from file, and ensure the next character is as expected.
+ * The call always succeeds (it dies() on failure).
+ */
+static int read_int_from_file(const char *path, char ending_char) {
 	char buf[BUFLEN], *end;
-	int state;
+	int value;
 
 	read_file(path, buf, BUFLEN);
 
-	state = strtol(buf, &end, 0);
-	if (*end && *end != '\n')
+	value = strtol(buf, &end, 0);
+	if (*end && *end != ending_char)
 		die("invalid file content: %s: %s", path, buf);
 
-	return state;
+	return value;
+}
+
+/*
+ * Write integer to file.
+ * The call always succeeds (it dies() on failure).
+ */
+static void write_int_to_file(const char *path, int value) {
+	char buf[BUFLEN];
+
+	snprintf(buf, BUFLEN, "%d\n", value);
+	write_file(path, buf, strlen(buf));
+}
+
+int get_sysrq_state(const char *path) {
+	return read_int_from_file(path, '\n');
 }
 
 void set_sysrq_state(const char *path, int new_state) {
-	char buf[BUFLEN];
-
-	snprintf(buf, BUFLEN, "%d\n", new_state);
-	write_file(path, buf, strlen(buf));
+	write_int_to_file(path, new_state);
 }
 
 int get_printk_console(const char *path) {
-	char buf[BUFLEN], *end;
-	int level;
-
-	read_file(path, buf, BUFLEN);
-
-	level = strtol(buf, &end, 0);
-	if (*end && *end != '\t')
-		die("invalid file content: %s: %s", path, buf);
-
-	return level;
+	return read_int_from_file(path, '\t');
 }
 
 void set_printk_console(const char *path, int new_level) {
-	char buf[BUFLEN];
-
-	snprintf(buf, BUFLEN, "%d\n", new_level);
-	write_file(path, buf, strlen(buf));
+	write_int_to_file(path, new_level);
 }

--- a/util.c
+++ b/util.c
@@ -103,3 +103,49 @@ void set_sysrq_state(const char *path, int new_state) {
 
 	fclose(ctl_file);
 }
+
+int get_printk_console(const char *path) {
+	char buf[BUFLEN], *end;
+	int len, level;
+	FILE *ctl_file;
+
+	if (!path)
+		return -1;
+
+	ctl_file = fopen(path, "r");
+	if (ctl_file == NULL)
+		die("could not open file: %s", path);
+
+	len = fread(buf, 1, BUFLEN - 1, ctl_file);
+	if (ferror(ctl_file))
+		die("could not read file: %s: %s", path, strerror(errno));
+
+	fclose(ctl_file);
+
+	buf[len] = '\0';
+	level = strtol(buf, &end, 0);
+	if (*end && *end != '\t')
+		die("invalid file content: %s: %s", path, buf);
+
+	return level;
+}
+
+void set_printk_console(const char *path, int new_level) {
+	char buf[BUFLEN];
+	FILE *ctl_file;
+
+	if (!path)
+		return;
+
+	ctl_file = fopen(path, "w+");
+	if (ctl_file == NULL)
+		die("could not open file: %s", path);
+
+	snprintf(buf, BUFLEN, "%d\n", new_level);
+
+	fwrite(buf, 1, strlen(buf), ctl_file);
+	if (ferror(ctl_file))
+		die("could not write file: %s: %s", path, strerror(errno));
+
+	fclose(ctl_file);
+}

--- a/util.h
+++ b/util.h
@@ -27,4 +27,7 @@ void die(const char*, ...);
 int get_sysrq_state(const char*);
 void set_sysrq_state(const char*, int);
 
+int get_printk_console(const char*);
+void set_printk_console(const char*, int);
+
 #endif /* UTIL_H */


### PR DESCRIPTION
My personal use-case:
I lock my computer with physlock automatically when the computer is
suspended. On resume, the kernel spits plenty of log messages to the
console, and the physlock prompt is lost inside this mess.

With an option to mute kernel logs messages, we can ensure that there's
nothing but the physlock prompt on the console, and it looks a lot
friendlier.