### PR TITLE
Added MOTD-File option

### DIFF
--- a/options.c
+++ b/options.c
@@ -45,14 +45,18 @@ void parse_options(int argc, char **argv) {
 	_options.disable_sysrq = 0;
 	_options.lock_switch = -1;
 	_options.mute_kernel_messages = 0;
+	_options.motd_file = NULL;
 
-	while ((opt = getopt(argc, argv, "dhLlmp:sv")) != -1) {
+	while ((opt = getopt(argc, argv, "df:hLlmp:sv")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
 				exit(1);
 			case 'd':
 				_options.detach = 1;
+				break;
+			case 'f':
+				_options.motd_file = optarg;
 				break;
 			case 'h':
 				print_usage();

--- a/options.h
+++ b/options.h
@@ -25,6 +25,7 @@ typedef struct options_s {
 	int lock_switch;
 	int mute_kernel_messages;
 	const char *prompt;
+	const char *motd_file;
 } options_t;
 
 extern const options_t *options;

--- a/physlock.1
+++ b/physlock.1
@@ -6,6 +6,8 @@ physlock \- lock all consoles / virtual terminals
 .RB [ \-dhLlmsv ]
 .RB [ \-p
 .IR MSG ]
+.RB [ \-f
+.IR MOTDFILE ]
 .SH DESCRIPTION
 physlock is an alternative to vlock, it is equivalent to `vlock \-an'. It is
 written because vlock blocks some linux kernel mechanisms like hibernate and
@@ -24,6 +26,11 @@ active tty) and prompts for her password to unlock the computer.
 Fork and detach physlock before prompting for authentication. The parent
 process returns right after everything is set up, so this option is useful for
 use in suspend/hibernate scripts.
+.TP
+.BI "\-f " MOTDFILE
+Display the Message Of The Day (motd) from 
+.I MOTDFILE
+before the password prompt. It is usually located in /etc/motd.
 .TP
 .B \-h
 Print brief usage information to standard output and exit.


### PR DESCRIPTION
Added `-f` as option in the manpage to load the message of the day.

Can also be used to load any kind of textfile. I have used it successfully with img2txt and now have colorful kittens as phslock-lockscreen.