### PR TITLE
Allow running of arbitrary commands before and after authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The following command-line arguments are supported:
     -l       only lock console switching
     -L       only enable console switching
     -m       mute kernel messages on console while physlock is running
+    -b CMD   execute CMD before the password prompt
+    -a CMD   execute CMD after successfully authenticating
+    -n       don't actually authenticate: just execute commands
     -p MSG   Display MSG before the password prompt
     -s       disable sysrq key while physlock is running
     -v       print version information and exit

--- a/main.c
+++ b/main.c
@@ -112,7 +112,7 @@ void run_command(const char* cmd) {
     } else if (cmdpid > 0) {
         wait(NULL);
     } else {
-        execlp("sh", "sh", "-c", cmd, NULL);
+        execl("/bin/sh", "sh", "-c", cmd, NULL);
         error(EXIT_FAILURE, errno, "exec");
     }
 }

--- a/options.c
+++ b/options.c
@@ -28,7 +28,7 @@ static options_t _options;
 const options_t *options = (const options_t*) &_options;
 
 void print_usage() {
-	printf("usage: physlock [-dhLlmsv] [-p MSG]\n");
+	printf("usage: physlock [-dhLlmsbanv] [-p MSG]\n");
 }
 
 void print_version() {

--- a/options.c
+++ b/options.c
@@ -37,7 +37,7 @@ void print_version() {
 
 void parse_options(int argc, char **argv) {
 	int opt;
-	
+
 	progname = strrchr(argv[0], '/');
 	progname = progname != NULL ? progname + 1 : argv[0];
 
@@ -45,8 +45,9 @@ void parse_options(int argc, char **argv) {
 	_options.disable_sysrq = 0;
 	_options.lock_switch = -1;
 	_options.mute_kernel_messages = 0;
+	_options.no_auth = 0;
 
-	while ((opt = getopt(argc, argv, "dhLlmp:sv")) != -1) {
+	while ((opt = getopt(argc, argv, "dhLlmnp:svb:a:")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -66,8 +67,17 @@ void parse_options(int argc, char **argv) {
 			case 'm':
 				_options.mute_kernel_messages = 1;
 				break;
+			case 'n':
+				_options.no_auth = 1;
+				break;
 			case 'p':
 				_options.prompt = optarg;
+				break;
+			case 'b':
+				_options.command_before = optarg;
+				break;
+			case 'a':
+				_options.command_after = optarg;
 				break;
 			case 's':
 				_options.disable_sysrq = 1;

--- a/physlock.1
+++ b/physlock.1
@@ -3,9 +3,13 @@
 physlock \- lock all consoles / virtual terminals
 .SH SYNOPSIS
 .B physlock
-.RB [ \-dhLlmsv ]
+.RB [ \-dhLlmnsv ]
 .RB [ \-p
 .IR MSG ]
+.RB [ \-b
+.IR CMD ]
+.RB [ \-a
+.IR CMD ]
 .SH DESCRIPTION
 physlock is an alternative to vlock, it is equivalent to `vlock \-an'. It is
 written because vlock blocks some linux kernel mechanisms like hibernate and
@@ -38,6 +42,15 @@ locked.
 .TP
 .B \-m
 Mute kernel messages on console while physlock is running.
+.TP
+.B "\-b " CMD
+Execute CMD before asking for password
+.TP
+.B "\-a " CMD
+Execute CMD after asking for password
+.TP
+.B \-n
+Don't ask for authentication: just execute commands
 .TP
 .BI "\-p " MSG
 Display

--- a/physlock.h
+++ b/physlock.h
@@ -54,7 +54,10 @@ typedef struct options_s {
 	int disable_sysrq;
 	int lock_switch;
 	int mute_kernel_messages;
+	int no_auth;
 	const char *prompt;
+	const char *command_before;
+	const char *command_after;
 } options_t;
 
 extern const options_t *options;


### PR DESCRIPTION
Let the user execute any command just before and after authenticating.
This allows for things like printing a different prompt each time, showing something just after unlocking,
etc - within physlock's VT.

As a bonus, add an option to not do any authentication at all - just execute the commands while having locked the screen. My personal favourite is running [sl](https://github.com/mtoyoda/sl) with no way whatsoever to interrupt it :)