### PR TITLE
Call pam_setcred after successful authentication

### DIFF
--- a/main.c
+++ b/main.c
@@ -197,6 +197,7 @@ int main(int argc, char **argv) {
 		u->pam_status = pam_authenticate(u->pamh, 0);
 		switch (u->pam_status) {
 		case PAM_SUCCESS:
+			pam_setcred(u->pamh, PAM_REFRESH_CRED);
 			locked = 0;
 			break;
 		case PAM_AUTH_ERR:


### PR DESCRIPTION
I'm not exactly sure, but I think after authenticating the user, `pam_setcred` should be called. This is mainly triggered by an issue I'm currently trying to solve (cruegge/pam-gnupg#7), but there is another case in i3lock (i3/i3lock#9), where not calling `pam_setcred` would not refresh Kerberos tickets.