### PR TITLE
Fix issue #97 with very basic signal handling

### DIFF
--- a/options.c
+++ b/options.c
@@ -28,7 +28,7 @@ static options_t _options;
 const options_t *options = (const options_t*) &_options;
 
 void print_usage() {
-	printf("usage: physlock [-dhLlmsv] [-p MSG]\n");
+	printf("usage: physlock [-dhLlmsvw] [-p MSG]\n");
 }
 
 void print_version() {
@@ -45,8 +45,9 @@ void parse_options(int argc, char **argv) {
 	_options.disable_sysrq = 0;
 	_options.lock_switch = -1;
 	_options.mute_kernel_messages = 0;
+	_options.staggered = 0;
 
-	while ((opt = getopt(argc, argv, "dhLlmp:sv")) != -1) {
+	while ((opt = getopt(argc, argv, "dhLlmp:svw")) != -1) {
 		switch (opt) {
 			case '?':
 				print_usage();
@@ -75,6 +76,9 @@ void parse_options(int argc, char **argv) {
 			case 'v':
 				print_version();
 				exit(0);
+			case 'w':
+				_options.staggered = 1;
+				break;
 		}
 	}
 }

--- a/physlock.1
+++ b/physlock.1
@@ -49,6 +49,14 @@ Disable SysRq mechanism while physlock is running.
 .TP
 .B \-v
 Print version information to standard output and exit.
+.TP
+.B \-w
+Wait until a SIGUSR1 signal is received to prompt for authentication.
+Useful if the first authentication attempt always fails
+due to bad input buffering in the virtual terminal.
+.BI WARNING:
+When using this option, ensure that some external program sends a SIGUSR1
+signal to physlock. Otherwise, you will be locked out of your session.
 .SH AUTHORS
 .TP
 Bert Muennich <ber.t at gmx.com>

--- a/physlock.h
+++ b/physlock.h
@@ -54,6 +54,7 @@ typedef struct options_s {
 	int disable_sysrq;
 	int lock_switch;
 	int mute_kernel_messages;
+	int staggered;
 	const char *prompt;
 } options_t;
 


### PR DESCRIPTION
This allows a fix for #97. Users can enable signal handling with the `-w` flag. When enabled, physlock waits until it receives a `SIGUSR1` before prompting for authentication. Therefore, users can send the signal after resume (via a systemd service, acpi event handler, etc.), avoiding the I/O buffer problem.